### PR TITLE
fix: Correct GitHub Actions commit hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -56,7 +56,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install JDK
         if: env.turbo_cache_hit != 1
-        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v5.1.0
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -133,7 +133,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup
         uses: ./.github/actions/setup
@@ -204,7 +204,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Setup
         uses: ./.github/actions/setup

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@30320c4495920c05a35f1dbb39b6f3b29f3667ae # v6.0.1
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
       - name: Label PR
         uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5.0.0


### PR DESCRIPTION
## Summary
PR #11のマージ時にハッシュ修正コミットが含まれず、誤ったコミットハッシュがmasterにマージされました。これを修正します。

## 問題
PR #11はsquash mergeされ、最初のコミット（`34eb4da`）のみがマージされました。ハッシュ修正コミット（`b67a159`）は含まれていません。

その結果、以下の誤ったハッシュがmasterブランチに残っています：
- `actions/checkout@v6.0.1`: `30320c4` (存在しない)
- `actions/setup-java@v5.1.0`: `7a6d8a8` (存在しない)

これにより、Dependabot PR #6-10のCIが全て失敗しています。

## 修正内容

正しいコミットハッシュに更新：
- `actions/checkout@v6.0.1`: `30320c4` → `8e8c483` ✅
- `actions/setup-java@v5.1.0`: `7a6d8a8` → `f2beeb2` ✅

## 影響範囲
- `.github/workflows/ci.yml`: 7箇所のactions/checkout、1箇所のactions/setup-java
- `.github/workflows/pr-check.yml`: 2箇所のactions/checkout

## Test plan
- [x] ハッシュの正しさを公式リリースページで確認済み
  - [actions/checkout v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)
  - [actions/setup-java v5.1.0](https://github.com/actions/setup-java/releases/tag/v5.1.0)
- [ ] PRマージ後、Dependabot PR #6-10のCIが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)