### PR TITLE
ci(deps): Upgrade actions/cache from v4.2.3 to v5.0.1

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,7 +18,7 @@ runs:
 
     - name: Restore dependencies
       id: pnpm-cache
-      uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/restore@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
       with:
         path: |
           **/node_modules
@@ -35,7 +35,7 @@ runs:
 
     - name: Cache dependencies
       if: steps.pnpm-cache.outputs.cache-hit != 'true'
-      uses: actions/cache/save@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      uses: actions/cache/save@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
       with:
         path: |
           **/node_modules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           /bin/bash -c "yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses > /dev/null"
 
       - name: Cache Gradle
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
           path: |
             ~/.gradle/wrapper


### PR DESCRIPTION
## Summary
- actions/cache を v4.2.3 → v5.0.1 へアップグレード
- Node.js 24対応（PR#33で対応済み）
- 新しいキャッシュバックエンドサービス（v2 API）による性能向上

## Background
- actions/cache v5 は Node.js 24 ランタイムを要求
- レガシーキャッシュサービスは 2025年2月1日 に終了予定
- 新しいキャッシュバックエンドにより、パフォーマンスと信頼性が向上

## Updated Locations
- `.github/workflows/ci.yml`: Gradle キャッシュ
- `.github/actions/setup/action.yml`: pnpm 依存関係キャッシュ（restore & save）

## Test plan
- [x] PR#33 でNode.js 24にアップグレード済み
- [x] 3箇所のactions/cache参照を全てv5.0.1に更新
- [ ] CI/CD が全て通ることを確認

## Related
- Built on top of PR#33 (Node.js 24 upgrade)
- Supersedes PR#26 (dependabot PR that was closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)